### PR TITLE
js: Fix spelling of *Received* functions

### DIFF
--- a/Project/js/peer-components.js
+++ b/Project/js/peer-components.js
@@ -90,11 +90,11 @@ WL.registerComponent("peer-manager", {
       connection.send({ joinedPlayers: Object.keys(this.activePlayers), joined: true});
     });
     connection.on("close", () => this._onHostConnectionClose(connection));
-    connection.on("data", (data) => this._onHostDataRecieved(data, connection));
+    connection.on("data", (data) => this._onHostDataReceived(data, connection));
     this.object.setTranslationWorld([0, 0, 0]);
   },
 
-  _onHostDataRecieved: function(data, connection) {
+  _onHostDataReceived: function(data, connection) {
     if (data.transforms && this.activePlayers[connection.peer]) {
       this.activePlayers[connection.peer].setTransforms(data.transforms);
     }
@@ -175,7 +175,7 @@ WL.registerComponent("peer-manager", {
     for (const cb of this.connectionEstablishedCallbacks) cb();
   },
 
-  _onClientDataRecieved: function(data) {
+  _onClientDataReceived: function(data) {
     const registeredCallbacksKeys = Object.keys(this.registeredNetworkCallbacks);
     const joined = "joined" in data;
 
@@ -286,7 +286,7 @@ WL.registerComponent("peer-manager", {
       metadata: { username: "TestName" },
     });
     this.connection.on("open", this._onClientConnected.bind(this));
-    this.connection.on("data", this._onClientDataRecieved.bind(this));
+    this.connection.on("data", this._onClientDataReceived.bind(this));
     this.connection.on("close", this._onClientClose.bind(this));
   },
 
@@ -326,12 +326,22 @@ WL.registerComponent("peer-manager", {
     this.disconnectCallbacks.splice(index, 1);
   },
 
-  addNetworkDataRecievedCallback: function(key, f) {
+  /* @deprecated Function was renamed to correct spelling */
+  addNetworkDataRecievedCallback: function(...args) {
+      return this.addNetworkDataReceivedCallback(...args);
+  },
+
+  addNetworkDataReceivedCallback: function(key, f) {
     this.registeredNetworkCallbacks = this.registeredNetworkCallbacks || {};
     this.registeredNetworkCallbacks[key] = f;
   },
 
-  removeNetworkDataRecievedCallback: function(key) {
+  /* @deprecated Function was renamed to correct spelling */
+  removeNetworkDataRecievedCallback: function(...args) {
+      return this.removeNetworkDataReceivedCallback(...args);
+  },
+
+  removeNetworkDataReceivedCallback: function(key) {
     delete this.registeredNetworkCallbacks[key];
   },
 


### PR DESCRIPTION
Hi @Srile,

This is a fairly simple fix, but confused someone using the library, so might be helpful for the future.
I left deprecated aliases for the old naming so that code continues to work.